### PR TITLE
CIV-10037 only get organisation id from the org service when role is …

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/enums/CaseRole.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/enums/CaseRole.java
@@ -13,6 +13,10 @@ public enum CaseRole {
 
     private String formattedName;
 
+    public boolean isProfessionalRole() {
+        return !(this == CLAIMANT || this == DEFENDANT);
+    }
+
     CaseRole() {
         this.formattedName = String.format("[%s]", name());
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/AssignCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/AssignCaseService.java
@@ -19,13 +19,25 @@ public class AssignCaseService {
 
     public void assignCase(String authorisation, String caseId, Optional<CaseRole> caseRole) {
         String userId = userService.getUserInfo(authorisation).getUid();
-        String organisationId = organisationService.findOrganisation(authorisation)
-            .map(Organisation::getOrganisationIdentifier).orElse(null);
+        String organisationId = getOrganisationId(authorisation, caseRole);
         coreCaseUserService.assignCase(
             caseId,
             userId,
             organisationId,
             caseRole.orElse(CaseRole.RESPONDENTSOLICITORONE)
         );
+    }
+
+    private String getOrganisationId(String authorisation, Optional<CaseRole> caseRole) {
+        String id = null;
+        if (caseRole.map(CaseRole::isProfessionalRole).orElse(false)) {
+            try {
+                id = organisationService.findOrganisation(authorisation)
+                    .map(Organisation::getOrganisationIdentifier).orElse(null);
+            } catch (Exception e) {
+                log.error("Error getting organisation id", e);
+            }
+        }
+        return id;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/AssignCaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/AssignCaseServiceTest.java
@@ -13,8 +13,11 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.reform.civil.enums.CaseRole.CLAIMANT;
+import static uk.gov.hmcts.reform.civil.enums.CaseRole.DEFENDANT;
 import static uk.gov.hmcts.reform.civil.enums.CaseRole.RESPONDENTSOLICITORONE;
 
 @ExtendWith(SpringExtension.class)
@@ -64,4 +67,15 @@ public class AssignCaseServiceTest {
             .assignCase(CASE_ID, UID, null, RESPONDENTSOLICITORONE);
     }
 
+    @Test
+    void shouldNotCallOrganisationServiceForCitizenRoleDefendant() {
+        assignCaseService.assignCase(AUTHORIZATION, CASE_ID, Optional.of(DEFENDANT));
+        verify(organisationService, never()).findOrganisation(anyString());
+    }
+
+    @Test
+    void shouldNotCallOrganisationServiceForCitizenRoleClaimant() {
+        assignCaseService.assignCase(AUTHORIZATION, CASE_ID, Optional.of(CLAIMANT));
+        verify(organisationService, never()).findOrganisation(anyString());
+    }
 }


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-10037


### Change description ###

only call organisation service when the user is in the professional category

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
